### PR TITLE
More strategies and more efficient XP gain for target monkey

### DIFF
--- a/bloons_farming.ahk
+++ b/bloons_farming.ahk
@@ -80,6 +80,7 @@ if (toggle) {
     timeEnd := A_TickCount
     totalTime := totalTime + (timeEnd - timeStart) / 1000
     tt("Functions stopped.")
+    tt(totalTime)
 }
 toggle := false
 return
@@ -218,7 +219,7 @@ Gui, Add, Text, xp+10 yp+18, Target Monkey:
 Gui, Add, DropDownList, vTargetMonkey, Dart|Boomerang|Bomb|Tack|Ice|Glue|Sniper|Mortar|Dartling|Wizard|Super|Ninja|Alchemist|Druid|Mermonkey|Spike|Village|Engineer|Handler
 GuiControl, ChooseString, TargetMonkey, %TargetMonkey%
 Gui, Add, Text,, Strategy:
-Gui, Add, DropDownList, vStrategy, Heli|Sniper
+Gui, Add, DropDownList, vStrategy, Heli|Sniper|Monkey Sub + Wizard
 GuiControl, ChooseString, Strategy, %Strategy%
 Gui, Add, CheckBox, Checked%ExtraDelay% vExtraDelay, Extra Delay
 Gui, Add, Button, gSaveButton xp ym+220 Default w80, &Save
@@ -356,10 +357,36 @@ while (toggle) {
             clickHere(110, 560)
             clickHere(110, 560)
         }
-        pressStream(",./,./,./,./,./,./")
+        if (Strategy="Monkey Sub + Wizard") {
+            press("a")                          ; place Wizard
+            clickHere(833, 789)
+            clickHere(833, 789)
+            pressStream("...//")
+            clickHere(0, 0)
+            press("a")                          ; place Wizard
+            clickHere(833, 292)
+            clickHere(833, 292)
+            pressStream("...//")
+            clickHere(0, 0)
+            press("x")                          ; place Sub
+            clickHere(473, 830)
+            clickHere(473, 830)
+            pressStream(",,////")
+            clickHere(0, 0)
+            press("x")
+            clickHere(1180,236)
+            clickHere(1180,236)
+            pressStream(",,///")
+            clickHere(0,0)
+            press()                                ; place target monkey
+            clickHere(506, 236)
+            clickHere(506, 236)
+        }
+        pressStream(",,,,,/////.....")
         clickHere(30, 0)
-        press("{Space}")                        ; start
-        press("{Space}")                        ; speed up
+        Click Right                        ; start
+        Sleep, InputDelay
+        Click Right                        ; speed up
         if (toggle) {
             step := 2
         }
@@ -379,6 +406,7 @@ while (toggle) {
                 clickHere(700, 800)             ; home button
                 checking := 0
                 games := games + 1
+                Gosub turnOff
                 step := 3
             }
             color := colorHere(925, 770)        ; check for defeat's restart button

--- a/bloons_farming.ahk
+++ b/bloons_farming.ahk
@@ -384,9 +384,8 @@ while (toggle) {
         }
         pressStream(",,,,,/////.....")
         clickHere(30, 0)
-        Click Right                        ; start
-        Sleep, InputDelay
-        Click Right                        ; speed up
+        press("{Space}")                        ; start
+        press("{Space}")                        ; speed up
         if (toggle) {
             step := 2
         }

--- a/bloons_farming.ahk
+++ b/bloons_farming.ahk
@@ -406,7 +406,6 @@ while (toggle) {
                 clickHere(700, 800)             ; home button
                 checking := 0
                 games := games + 1
-                Gosub turnOff
                 step := 3
             }
             color := colorHere(925, 770)        ; check for defeat's restart button


### PR DESCRIPTION
### TIMINGS:

**308.125s for Heli with 2,160 money left over  for XP
323.64s for Sniper with 7,380 left over for XP
339.500s for Monkey Sub and Wizard with 2,500 money left over for XP**


So Monkey Sub and Wizard is slower, but it is safer than Sniper with more money left over for XP than Heli. It also farms Wizard and Sub XP really quickly.
Also changed your Target Monkey upgrade system, as trying to maxx out one path first before crosspathing leads to more money spent on the tower (and less money left over at the end). This means your target monkey will get more XP.