### PR TITLE
Fixed #26, Implemented #4, Enabled Ace Monkey Fixed #1, Fixed #26, Implemented #4, Enabled Ace Monkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Newer, may lose some lives but has more leftover cash for XP monkey
         - [Tutorial](https://youtu.be/WVw36Pxh0GI?feature=shared)
 - Mermonkey hotkey is unset by default, **set it to the previously unused "o" key for the script to work**
     - Default being unset is likely due to the other default hotkey assignments not leaving space for Mermonkey to be assigned beside the other magic monkeys
-- Due to issue https://github.com/gavboi/btd6-farming/issues/1, the script will need to be babysat while the tower is unlocking the initial upgrades
 
 ### Full Controls
 

--- a/bloons_farming.ahk
+++ b/bloons_farming.ahk
@@ -374,6 +374,8 @@ while (toggle) {
             }
         }
         pressStream(",./,./,./,./,./,./")
+        Sleep TransitionDelay
+        clickHere(84, 94) ; close upgrade screen
         clickHere(30, 0)
         press("{Space}")                        ; start
         press("{Space}")                        ; speed up

--- a/bloons_farming.ahk
+++ b/bloons_farming.ahk
@@ -162,8 +162,9 @@ press(key:=false) {
     global hotkey_dict
     global TargetMonkey
     global InputDelay
-    if !key
+    if (!key) {
         key := hotkey_dict[TargetMonkey]
+    }
     SendInput %key%
     Sleep InputDelay
     return
@@ -215,7 +216,7 @@ Gui, Add, Tab3,, Control|Tracking|Help|
 Gui, Tab, 1 ; Control
 Gui, Add, GroupBox, Section w200 h170, Options
 Gui, Add, Text, xp+10 yp+18, Target Monkey:
-Gui, Add, DropDownList, vTargetMonkey, Dart|Boomerang|Bomb|Tack|Ice|Glue|Sniper|Mortar|Dartling|Wizard|Super|Ninja|Alchemist|Druid|Mermonkey|Spike|Village|Engineer|Handler
+Gui, Add, DropDownList, vTargetMonkey, Dart|Boomerang|Bomb|Tack|Ice|Glue|Sniper|Sub|Buccaneer|Ace|Mortar|Dartling|Wizard|Super|Ninja|Alchemist|Druid|Mermonkey|Spike|Village|Engineer|Handler
 GuiControl, ChooseString, TargetMonkey, %TargetMonkey%
 Gui, Add, Text,, Strategy:
 Gui, Add, DropDownList, vStrategy, Heli|Sniper
@@ -248,6 +249,12 @@ InputDelay := BaseInputDelay * (1+ExtraDelay)
 TransitionDelay := BaseTransitionDelay * (1+ExtraDelay)
 BTDFGuiClose:
 Gui, BTDF:Destroy
+global WaterMonkeyTarget
+if (TargetMonkey = "sub" or TargetMonkey = "buccaneer") {
+    WaterMonkeyTarget := true
+} else {
+    WaterMonkeyTarget := false 
+}
 menuOpen := false
 Sleep 250
 if (toggleText="On") {
@@ -333,8 +340,13 @@ while (toggle) {
             pressStream(",,,..")
             clickHere(0, 0)
             press()                                ; place target monkey
-            clickHere(835, 745)
-            clickHere(835, 745)
+            if (WaterMonkeyTarget) {
+                clickHere(482, 867)
+                clickHere(482, 867)
+            } else {
+                clickHere(835, 745)
+                clickHere(835, 745)
+            }
         }
         if (Strategy="Sniper") {
             press("k")                          ; place village
@@ -353,8 +365,13 @@ while (toggle) {
             pressStream(",,,/")
             clickHere(0, 0)
             press()                                ; place target monkey
-            clickHere(110, 560)
-            clickHere(110, 560)
+            if (WaterMonkeyTarget) {
+                clickHere(482, 867)
+                clickHere(482, 867)
+            } else {
+                clickHere(110, 560)
+                clickHere(110, 560)
+            }
         }
         pressStream(",./,./,./,./,./,./")
         clickHere(30, 0)
@@ -402,12 +419,21 @@ while (toggle) {
         }
         if (step=3) {                           ; STEP 3: LOAD HOME SCREEN
             color := 0
+            step3StartTime := A_TickCount
+            setStepTo1 := true
             while (!nearColor(color, 0xffffff) and toggle and !menuOpen) {    ; wait for home screen
                 tt("Waiting for menu...")
                 color := colorHere(830, 930)
                 Sleep InputDelay
+                if (A_TickCount - step3StartTime > 5000) {
+                    step := 2
+                    setStepTo1 := false 
+                    break ; go back to step 2 if we failed to get to home screen for over 5 seconds
+                }
             }
-            step := 1
+            if (setStepTo1) {
+                step := 1
+            }
         }
     }
 }

--- a/bloons_farming.ahk
+++ b/bloons_farming.ahk
@@ -297,7 +297,7 @@ while (toggle) {
     if (step=1) {                                ; STEP 1.1: MENU
         Hotkey, ^m, Off
         tt("Starting round...")
-        clickHere(835, 935)                        ; click play
+        clickHere(953, 983)                        ; click play
         Sleep TransitionDelay
         clickHere(1340, 975)                    ; click expert maps
         Sleep TransitionDelay
@@ -423,9 +423,9 @@ while (toggle) {
             color := 0
             step3StartTime := A_TickCount
             setStepTo1 := true
-            while (!nearColor(color, 0xffffff) and toggle and !menuOpen) {    ; wait for home screen
+            while (!nearColor(color, 0x00E5FF) and toggle and !menuOpen) {    ; wait for home screen
                 tt("Waiting for menu...")
-                color := colorHere(830, 930)
+                color := colorHere(737, 863)
                 Sleep InputDelay
                 if (A_TickCount - step3StartTime > 5000) {
                     step := 2


### PR DESCRIPTION

 Fixed start button location and detection (changed with addition of legends, so script stopped working).

    Fixed #1 (we just press where we would close the xp upgrade window after attempting to upgrade the target monkey after a transition delay).
    Fixed #26 (the script would randomly detect the end of the game early, resulting in it getting stuck on the victory screen). This was fixed by going back to step 2 if we find ourselves waiting for the home screen for more than 5 seconds in step 3.
    Added support for water monkeys with both strategies (#4)
    Even though ace monkey can be afforded without monkey knowledge on both strategies, it was not enabled in the settings menu. It now is.
